### PR TITLE
Update Dockerfile to fix open issue #100 (on Windows)

### DIFF
--- a/dockers/debian9/Dockerfile
+++ b/dockers/debian9/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update --yes && apt-get install --no-install-recommends --yes \
   libboost-test-dev \
   libssl-dev \
   libcurl4-openssl-dev \
+  libxml2-dev \
   libz-dev \
   curl \
   libhdf5-cpp-100 \ 


### PR DESCRIPTION
Current Docker image doesn't include libxml2-devel, which prevents installation of R libraries xml2 and thus devtools. This throws the error referenced in https://github.com/velocyto-team/velocyto.R/issues/100 on Windows (Linux Docker on Windows 10 Pro) and apparently on Mac as well. Adding libxml2-dev to dockerfile seems to fix the issue.